### PR TITLE
Fix tcl syntax in an example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ foreach ent $gridEntsToExport {
 }
 
 # Access the pw::Connector (2D) or a pw::Domain (3D) boundary cells.
-bcNames [pw::BoundaryCondition getNames]
+set bcNames [pw::BoundaryCondition getNames]
 foreach bcName $bcNames {
   set bc [pw::BoundaryCondition getByName $bcName]
   # Get the boundary grid entites using $bc. $bcEnts will contain


### PR DESCRIPTION
A variable was not 'set' properly.

Hey Pointwise, I just noticed that by branch was a commit ahead of yours. I made this small, but substantial fix to the README.md file some time ago. You might want to include it?

Thanks!
